### PR TITLE
Add tests for more reducers

### DIFF
--- a/src/shared/actions/api.js
+++ b/src/shared/actions/api.js
@@ -5,8 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 import {
-  API_ADMIN, API_SETADMINPARAMETERS,
-  API_GETMIDDLEWARES, API_SETMIDDLEWARE, API_DELETEMIDDLEWARE,
+  API_ADMIN,
+  API_DELETEMIDDLEWARE,
+  API_GETMIDDLEWARES,
+  API_SETADMINPARAMETERS,
+  API_SETMIDDLEWARE,
   FETCH_REQUEST,
 } from "./";
 
@@ -15,17 +18,32 @@ export function apiAdminRequest() {
 }
 
 export function apiSetAdminParametersRequest(params) {
-  return { type: API_SETADMINPARAMETERS + FETCH_REQUEST, params };
+  return {
+    type: API_SETADMINPARAMETERS + FETCH_REQUEST,
+    params,
+  };
 }
 
 export function apiGetMiddlewaresRequest(botId, middlewareType = null) {
-  return { type: API_GETMIDDLEWARES + FETCH_REQUEST, botId, middlewareType };
+  return {
+    type: API_GETMIDDLEWARES + FETCH_REQUEST,
+    botId,
+    middlewareType,
+  };
 }
 
 export function apiSetMiddlewareRequest(botId, middleware) {
-  return { type: API_SETMIDDLEWARE + FETCH_REQUEST, botId, middleware };
+  return {
+    type: API_SETMIDDLEWARE + FETCH_REQUEST,
+    botId,
+    middleware,
+  };
 }
 
 export function apiDeleteMiddlewareRequest(botId, middlewareId) {
-  return { type: API_DELETEMIDDLEWARE + FETCH_REQUEST, botId, middlewareId };
+  return {
+    type: API_DELETEMIDDLEWARE + FETCH_REQUEST,
+    botId,
+    middlewareId,
+  };
 }

--- a/src/shared/actions/app.js
+++ b/src/shared/actions/app.js
@@ -7,9 +7,15 @@
 import { APP_SETTITLE, APP_SETNAME } from "./";
 
 export function appSetTitle(titleName) {
-  return { type: APP_SETTITLE, titleName };
+  return {
+    type: APP_SETTITLE,
+    titleName,
+  };
 }
 
 export function appSetName(appName) {
-  return { type: APP_SETNAME, appName };
+  return {
+    type: APP_SETNAME,
+    appName,
+  };
 }

--- a/src/shared/actions/auth.js
+++ b/src/shared/actions/auth.js
@@ -4,7 +4,13 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { AUTH_SIGNIN, AUTH_SIGNOUT, FETCH_REQUEST, FETCH_SUCCESS, FETCH_FAILURE } from "./";
+import {
+  AUTH_SIGNIN,
+  AUTH_SIGNOUT,
+  FETCH_REQUEST,
+  FETCH_SUCCESS,
+  FETCH_FAILURE,
+} from "./";
 
 export function signIn({ provider, username, password }) {
   return {

--- a/src/shared/actions/initialize.js
+++ b/src/shared/actions/initialize.js
@@ -1,3 +1,4 @@
+/* eslint import/prefer-default-export:0 */
 /**
  * Copyright (c) 2015-present, CWB SAS
  *
@@ -7,10 +8,8 @@
 import { AUTH_INIT_SETTINGS } from "./";
 
 export function initAuthSettings(config) {
-  return { type: AUTH_INIT_SETTINGS, config };
-}
-
-export function resetSettings(config) {
-  // TODO
-  return { type: AUTH_INIT_SETTINGS, config };
+  return {
+    type: AUTH_INIT_SETTINGS,
+    config,
+  };
 }

--- a/src/shared/actions/user.js
+++ b/src/shared/actions/user.js
@@ -28,7 +28,3 @@ export function apiUserProfileError({ error }) {
     error,
   };
 }
-
-export function apiSaveUserProfileRequest() {
-  return { type: API_USERPROFILE + FETCH_REQUEST };
-}

--- a/src/shared/reducers/app.js
+++ b/src/shared/reducers/app.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { createReducer } from "./";
+import createReducer from "./createReducer";
 import {
   APP_SETTITLE, API_ADMIN, API_SETADMINPARAMETERS,
   API_GETMIDDLEWARES, API_SETMIDDLEWARE, API_DELETEMIDDLEWARE,

--- a/src/shared/reducers/app.js
+++ b/src/shared/reducers/app.js
@@ -6,22 +6,32 @@
  */
 import createReducer from "./createReducer";
 import {
-  APP_SETTITLE, API_ADMIN, API_SETADMINPARAMETERS,
-  API_GETMIDDLEWARES, API_SETMIDDLEWARE, API_DELETEMIDDLEWARE,
+  API_ADMIN,
+  API_DELETEMIDDLEWARE,
+  API_GETMIDDLEWARES,
+  API_SETADMINPARAMETERS,
+  API_SETMIDDLEWARE,
+  APP_SETTITLE,
   AUTH_SIGNOUT,
-  FETCH_REQUEST, FETCH_SUCCESS, FETCH_FAILURE,
+  FETCH_FAILURE,
+  FETCH_REQUEST,
+  FETCH_SUCCESS,
 } from "../actions";
 
-const initialState = {
-  loading: false,
+export const initialState = {
   admin: null,
-  titleName: "",
   error: null,
+  loading: false,
+  titleName: "",
 };
 
 export default createReducer(initialState, {
   /* API section */
-  [API_ADMIN + FETCH_REQUEST]: state => ({ ...state, loading: true, error: null }),
+  [API_ADMIN + FETCH_REQUEST]: state => ({
+    ...state,
+    loading: true,
+    error: null,
+  }),
   [API_ADMIN + FETCH_SUCCESS]: (state, { admin }) => ({
     ...state, loading: false, error: null, admin: { ...admin },
   }),

--- a/src/shared/reducers/auth.js
+++ b/src/shared/reducers/auth.js
@@ -5,9 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 import createReducer from "./createReducer";
-import { AUTH_SIGNIN, FETCH_REQUEST, FETCH_SUCCESS, FETCH_FAILURE, AUTH_SIGNOUT } from "../actions";
+import {
+  AUTH_SIGNIN,
+  AUTH_SIGNOUT,
+  FETCH_FAILURE,
+  FETCH_REQUEST,
+  FETCH_SUCCESS,
+} from "../actions";
 
-const initialState = {
+export const initialState = {
   loading: false,
   error: null,
   username: null,
@@ -19,24 +25,41 @@ export default createReducer(initialState, {
   [AUTH_SIGNIN + FETCH_REQUEST]: (state, { provider, username, password }) => {
     let newState;
     if (provider) {
-      newState = { ...state, [provider]: { loading: false, error: null } };
+      newState = {
+        ...state,
+        [provider]: {
+          loading: true,
+          error: null,
+        },
+      };
     } else {
-      newState = { ...state, loading: false, error: null };
+      newState = {
+        ...state,
+        loading: true,
+        error: null,
+      };
     }
+
     return {
-      ...newState, username, password, provider,
+      ...newState,
+      password,
+      provider,
+      username,
     };
   },
   [AUTH_SIGNIN + FETCH_SUCCESS]: (state, { provider }) => {
     if (provider) {
       return {
-        provider: {
+        ...state,
+        [provider]: {
           loading: false,
           error: null,
         },
       };
     }
+
     return {
+      ...state,
       loading: false,
       error: null,
     };
@@ -44,21 +67,31 @@ export default createReducer(initialState, {
   [AUTH_SIGNIN + FETCH_FAILURE]: (state, { provider, error }) => {
     if (provider) {
       return {
+        ...state,
         [provider]: {
           loading: false,
           error,
         },
       };
     }
+
     return {
+      ...state,
       loading: false,
       error,
     };
   },
-  [AUTH_SIGNOUT + FETCH_SUCCESS]: () => ({ ...initialState }),
-  [AUTH_SIGNOUT + FETCH_REQUEST]: state => ({ ...state, loading: true, error: null }),
-
-  [AUTH_SIGNOUT + FETCH_SUCCESS]: () => ({ ...initialState }),
-
-  [AUTH_SIGNOUT + FETCH_FAILURE]: (state, { error }) => ({ ...state, loading: false, error }),
+  [AUTH_SIGNOUT + FETCH_REQUEST]: state => ({
+    ...state,
+    loading: true,
+    error: null,
+  }),
+  [AUTH_SIGNOUT + FETCH_SUCCESS]: () => ({
+    ...initialState,
+  }),
+  [AUTH_SIGNOUT + FETCH_FAILURE]: (state, { error }) => ({
+    ...state,
+    loading: false,
+    error,
+  }),
 });

--- a/src/shared/reducers/createReducer.js
+++ b/src/shared/reducers/createReducer.js
@@ -1,25 +1,14 @@
-/*
-http://redux.js.org/docs/recipes/ReducingBoilerplate.html
-Modified for ESlint and ES6
-*/
+/* eslint arrow-body-style: 0 */
 
-/*
-Why this code isn't working ?
-
-const createReducer = (initialState, handlers) => (state = initialState, action) => {
-  if (Object.prototype.hasOwnProperty.call(handlers, action.type)) {
-    return handlers[action.type](state, action);
-  }
-  return state;
-};
-export { createReducer };
-*/
-
-export default function createReducer(initialState, handlers) {
-  return (state = initialState, action) => {
+// Based on: http://redux.js.org/docs/recipes/ReducingBoilerplate.html
+const createReducer = (initialState, handlers) => {
+  return (state = initialState, action = {}) => {
     if (Object.prototype.hasOwnProperty.call(handlers, action.type)) {
       return handlers[action.type](state, action);
     }
+
     return state;
   };
-}
+};
+
+export default createReducer;

--- a/tests/shared/reducers/app.test.js
+++ b/tests/shared/reducers/app.test.js
@@ -1,0 +1,21 @@
+import * as apiActions from "@shared/actions/api";
+import reducer, { initialState } from "@shared/reducers/app";
+
+describe("reducers/app", () => {
+  it("returns the initial state", () => {
+    const state = reducer(undefined, {});
+    expect(state).toEqual(initialState);
+  });
+
+  it("requests the admin API", () => {
+    const prevState = reducer(undefined, {});
+    expect(prevState).toEqual(initialState);
+
+    const state = reducer(prevState, apiActions.apiAdminRequest());
+    expect(state).toEqual({
+      ...prevState,
+      loading: true,
+      error: null,
+    });
+  });
+});

--- a/tests/shared/reducers/auth.test.js
+++ b/tests/shared/reducers/auth.test.js
@@ -1,0 +1,169 @@
+import * as actions from "@shared/actions/auth";
+import reducer, { initialState } from "@shared/reducers/auth";
+
+describe("reducers/auth", () => {
+  it("returns the initial state", () => {
+    const state = reducer(undefined, {});
+    expect(state).toEqual(initialState);
+  });
+
+  it("requests sign in with a provider", () => {
+    const provider = "some provider";
+    const username = 'johndoe';
+    const password = 'secret';
+
+    const prevState = reducer(undefined, {});
+    expect(prevState).toEqual(initialState);
+
+    const state = reducer(prevState, actions.signIn({
+      password,
+      provider,
+      username,
+    }));
+    expect(state).toEqual({
+      ...prevState,
+      [provider]: {
+        loading: true,
+        error: null,
+      },
+      password,
+      provider,
+      username,
+    });
+  });
+
+  it("requests sign in without a provider", () => {
+    const username = 'johndoe';
+    const password = 'secret';
+
+    const prevState = reducer(undefined, {});
+    expect(prevState).toEqual(initialState);
+
+    const state = reducer(prevState, actions.signIn({
+      username,
+      password,
+    }));
+    expect(state).toEqual({
+      ...prevState,
+      loading: true,
+      password,
+      provider: undefined,
+      username,
+    });
+  });
+
+  it("signs in a user with a provider", () => {
+    const provider = "some provider";
+    const username = 'johndoe';
+    const password = 'secret';
+
+    const prevState = reducer(undefined, {});
+    expect(prevState).toEqual(initialState);
+
+    const state = reducer(prevState, actions.signInComplete({
+      password,
+      provider,
+      username,
+    }));
+    expect(state).toEqual({
+      ...prevState,
+      [provider]: {
+        loading: false,
+        error: null,
+      },
+    });
+  });
+
+  it("signs in a user without a provider", () => {
+    const username = 'johndoe';
+    const password = 'secret';
+
+    const prevState = reducer(undefined, {});
+    expect(prevState).toEqual(initialState);
+
+    const state = reducer(prevState, actions.signInComplete({
+      password,
+      username,
+    }));
+    expect(state).toEqual({
+      ...prevState,
+      loading: false,
+      error: null,
+    });
+  });
+
+  it("handles sign in errors with a provider", () => {
+    const error = "some error";
+    const provider = "some provider";
+
+    const prevState = reducer(undefined, {});
+    expect(prevState).toEqual(initialState);
+
+    const state = reducer(prevState, actions.signInError({
+      error,
+      provider
+    }));
+    expect(state).toEqual({
+      ...prevState,
+      [provider]: {
+        error,
+        loading: false,
+      },
+    });
+  });
+
+  it("handles sign in errors without a provider", () => {
+    const error = "some error";
+
+    const prevState = reducer(undefined, {});
+    expect(prevState).toEqual(initialState);
+
+    const state = reducer(prevState, actions.signInError({ error }));
+    expect(state).toEqual({
+      ...prevState,
+      error,
+      loading: false,
+    });
+  });
+
+  it("requests sign out", () => {
+    const provider = "some provider";
+
+    const prevState = reducer(undefined, {});
+    expect(prevState).toEqual(initialState);
+
+    const state = reducer(prevState, actions.signOut({ provider }));
+    expect(state).toEqual({
+      ...prevState,
+      loading: true,
+    });
+  });
+
+  it("signs out a user", () => {
+    const provider = "some provider";
+
+    const prevState = reducer(undefined, {});
+    expect(prevState).toEqual(initialState);
+
+    const state = reducer(prevState, actions.signOutComplete({ provider }));
+    expect(state).toEqual(initialState);
+  });
+
+  it("handles sign out errors", () => {
+    const error = "some error";
+    const provider = "some provider";
+
+    const prevState = reducer(undefined, {});
+    expect(prevState).toEqual(initialState);
+
+    const state = reducer(prevState, actions.signOutError({
+      error,
+      provider,
+    }));
+    expect(state).toEqual({
+      ...prevState,
+      error,
+      loading: false,
+    });
+  });
+});

--- a/tests/shared/reducers/createReducer.test.js
+++ b/tests/shared/reducers/createReducer.test.js
@@ -1,0 +1,29 @@
+import createReducer from "@shared/reducers/createReducer";
+
+describe("reducers/createReducer", () => {
+  it("creates a reducer", () => {
+    const initialState = { foo: 'foo' };
+    const handlers = {};
+
+    const reducer = createReducer(initialState, handlers);
+
+    expect(reducer).toBeInstanceOf(Function);
+    // always returns initialState if nothing is supplied
+    expect(reducer()).toEqual(initialState);
+  });
+
+  it("calls a handler if it exists", () => {
+    const initialState = { foo: 'foo' };
+    const handlers = {
+      'MY_HANDLER': (state) => ({ ...state, foo: 'new-value' }),
+    };
+
+    const reducer = createReducer(initialState, handlers);
+
+    const state = reducer(undefined, { type: 'MY_HANDLER' });
+    expect(state).toEqual({
+      ...initialState,
+      foo: 'new-value',
+    });
+  });
+});

--- a/tests/shared/reducers/index.test.js
+++ b/tests/shared/reducers/index.test.js
@@ -1,0 +1,14 @@
+import rootReducer from "@shared/reducers";
+
+describe("reducers/index", () => {
+  it("combines all the reducers", () => {
+    const reducerNames = Object.keys(rootReducer()).sort();
+
+    expect(reducerNames).toEqual([
+      "app",
+      "auth",
+      "initialize",
+      "user",
+    ]);
+  });
+});

--- a/tests/shared/reducers/initialize.test.js
+++ b/tests/shared/reducers/initialize.test.js
@@ -1,14 +1,14 @@
-import * as actions from '@shared/actions/initialize';
-import reducer, { initialState } from '@shared/reducers/initialize';
+import * as actions from "@shared/actions/initialize";
+import reducer, { initialState } from "@shared/reducers/initialize";
 
-describe('reducers/initialize', () => {
-  it('returns the initial state', () => {
+describe("reducers/initialize", () => {
+  it("returns the initial state", () => {
     const state = reducer(undefined, {});
     expect(state).toEqual(initialState);
   });
 
-  it('initializes the auth settings', () => {
-    const fakeConfig = { foo: 'bar' };
+  it("initializes the auth settings", () => {
+    const fakeConfig = { foo: "bar" };
 
     const prevState = reducer(undefined, {});
     expect(prevState).toEqual(initialState);


### PR DESCRIPTION
This PR adds tests for the `auth` reducer, `createReducer` helper and combined reducer. The `app` reducer will follow in a separate PR.