### PR TITLE
Add default config

### DIFF
--- a/src/shared/config.js
+++ b/src/shared/config.js
@@ -4,4 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-// TODO
+
+// This file should be aliased in webpack configuration.
+export default {};

--- a/src/shared/services.js
+++ b/src/shared/services.js
@@ -1,10 +1,11 @@
 import { WebService, AuthService, SocketService } from "zoapp-common";
+import defaultConfig from "./config";
 
 let authService;
 
 let webService;
 
-export function initServices(config) {
+export function initServices(config = defaultConfig) {
   const { backend } = config;
 
   let { host, port, path } = backend.auth;


### PR DESCRIPTION
This allows to override the `webpack` config and load the correct configuration
file from the main/root application.

See: https://github.com/Opla/front/blob/1b10a3714818db2e62705522e2d45c7393ac5d7e/webpack.common.js#L24