### PR TITLE
require react and react-dom as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,6 @@
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "prop-types": "15.6.0",
-    "react": "^16.2.0",
-    "react-dom": "16.2.0",
     "react-hot-loader": "^4.0.0",
     "react-redux": "5.0.6",
     "react-router": "^4.2.0",
@@ -47,6 +45,10 @@
     "zoapp-common": "0.1.2",
     "zoapp-ui": "0.4.7",
     "zrmc": "^0.8.1"
+  },
+  "peerDependencies": {
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
to resolve the problem we have in https://github.com/Opla/front/pull/71 I would like to try to require `react` and `react-dom` as a peer dependency