### PR TITLE
check classes type in displayWebServiceEditor to display it correctly

### DIFF
--- a/src/shared/components/displayWebServiceEditor.jsx
+++ b/src/shared/components/displayWebServiceEditor.jsx
@@ -18,8 +18,12 @@ const displayWebServiceEditor = (
 ) => {
   const name = parameters.name ? parameters.name : "";
   const url = parameters.url ? parameters.url : "";
-  const classes = parameters.classes ? parameters.classes : "";
+  let classes = parameters.classes ? parameters.classes : "";
   const secret = parameters.secret ? parameters.secret : "";
+
+  if (classes instanceof Array) {
+    classes = classes.join(",");
+  }
 
   const content = (
     <div>

--- a/tests/shared/components/displayWebServiceEditor.test.js
+++ b/tests/shared/components/displayWebServiceEditor.test.js
@@ -13,7 +13,9 @@ describe("displayWebServiceEditor", () => {
     const title = "a title";
     const action = "an action";
     const actionDef = "an action def";
-    const parameters = {};
+    const parameters = {
+      classes: ["foo", "bar", "baz"],
+    };
     const setInput = jest.fn();
     const onEditAction = jest.fn();
     const className = "";


### PR DESCRIPTION
`classes` variable can be an array or a string. If it's an array we need to "stringify" it to display it correctly. Then it will be transform in an array.

I don't know if this should be done here or in this component https://github.com/Opla/front/blob/master/src/shared/containers/servicesContainer.jsx