### PR TITLE
prevent to fire twice onSelect event in ServicesList component

### DIFF
--- a/src/shared/components/servicesList.jsx
+++ b/src/shared/components/servicesList.jsx
@@ -43,7 +43,16 @@ const ServicesList = ({ name, items, onSelect, addDisabled }) => (
             className={classes}
             onClick={(e) => {
               e.preventDefault();
-              if (onSelect) {
+              let role;
+              if (
+                Object.prototype.hasOwnProperty.call(
+                  e.target.attributes,
+                  "role",
+                )
+              ) {
+                role = e.target.attributes.role.value;
+              }
+              if (onSelect && role !== "button") {
                 onSelect({
                   name,
                   state: "select",


### PR DESCRIPTION
in this component, two events are fired when you click on the `close` icon. The `onClick` on the close icon but also the `onClick` on the parent component. To prevent this I check the target component and determine if yes or not the event should be fired