### PR TITLE
set auth to false in getAdminParameters API call

### DIFF
--- a/src/shared/sagas/api.js
+++ b/src/shared/sagas/api.js
@@ -67,10 +67,11 @@ const api = [
       try {
         let response;
         if (parameterType === null) {
-          response = yield getWebService().get(`params/${name}`);
+          response = yield getWebService().get(`params/${name}`, false);
         } else {
           response = yield getWebService().get(
             `params/${name}/${parameterType}`,
+            false,
           );
         }
 


### PR DESCRIPTION
those endpoint are public so `auth` must be set to `false`.