### PR TITLE
Add handleToolbarTabChange as screen render props

### DIFF
--- a/src/shared/containers/app.jsx
+++ b/src/shared/containers/app.jsx
@@ -282,6 +282,7 @@ class App extends React.Component {
                     ...props,
                     screen,
                     activeTab,
+                    handleToolbarTabChange: this.handleToolbarTabChange,
                   });
                 }
                 return <Screen screen={screen}>{screen.name}</Screen>;


### PR DESCRIPTION
Needed in order to redirect dashboard to builder ( Linked to PR Opla/opla#126 [here](https://github.com/Opla/opla/pull/126#issuecomment-440757940) , originally from issue Opla/opla#109)