### PR TITLE
[WIP] Screen plugin view render

### DIFF
--- a/src/shared/containers/app.jsx
+++ b/src/shared/containers/app.jsx
@@ -59,6 +59,7 @@ class App extends React.Component {
     this.props.initAuthSettings();
     this.updateAdmin();
     Zrmc.init(this, { typography: true });
+    this.props.apiGetPluginsRequest(this.props.selectedBotId);
   }
 
   componentDidUpdate(prevProps) {
@@ -520,6 +521,7 @@ const mapStateToProps = (state) => {
     name: state.app.activeScreen.name ? state.app.activeScreen.name : "",
   };
 
+  const { frontPlugins = [] } = state.app;
   const { activeTab } = state.app;
 
   const selectedBotId = state.app ? state.app.selectedBotId : null;
@@ -537,9 +539,10 @@ const mapStateToProps = (state) => {
       });
     }
   });
+  const findRenderViewByPluginName = (screenPluginName, fps) =>
+    (fps.find((fp) => fp.name === screenPluginName) || {}).renderView;
 
   const newScreens = [...screens];
-
   screenPlugins.forEach((screenPlugin) => {
     if (screenPlugin.middleware && screenPlugin.middleware.screen) {
       const addScreen = screenPlugin.middleware.screen;
@@ -555,6 +558,7 @@ const mapStateToProps = (state) => {
         path: "#",
         access: "all",
         ...screenPlugin.middleware.screen,
+        render: findRenderViewByPluginName(screenPlugin.name, frontPlugins),
       });
     }
   });


### PR DESCRIPTION
# Description

Add new property in App to handle plugins that render views.
`frontPlugins` should be passed as property. 

Need to add a sample plugin to demonstrate this feature

## Type of change

- [x] Other (non-breaking change which doesn't match an issue, Non-code related, ...)

# How Has This Been Tested?

Currently WIP

**Test Configuration**:
* Yarn/npm/nodejs version: v1.12.1/v5.6.0/v8.11.4
* OS version: macOS 10.14.2
* Chrome version: Google Chrome 71.0.3578.98

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
